### PR TITLE
와인목록페이지 카드와인리스트 구현

### DIFF
--- a/src/components/cardwine/cardwine.tsx
+++ b/src/components/cardwine/cardwine.tsx
@@ -42,5 +42,5 @@ const CardWine: React.FC<CardProps> = ({ image, wineName, wineDesc, winePrice, r
     //</div>
   );
 };
-
+//
 export default CardWine;


### PR DESCRIPTION
-scss가 적용이 안되었던 이유가 cardwine컴포넌트가 card로 되어있어 다른 속성명이 중첩되어 오류가 발생하여 수정하였습니다.